### PR TITLE
fix: rename 'tag' labels to 'mot-clé' in UI

### DIFF
--- a/src/pages/Dhikrs.tsx
+++ b/src/pages/Dhikrs.tsx
@@ -176,7 +176,7 @@ export const Dhikrs: React.FC = () => {
                         <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-amber-200 dark:border-emerald-800">
                             <div className="flex items-center gap-2 mb-4">
                                 <Tags className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-                                <h3 className="text-lg font-semibold text-emerald-900 dark:text-emerald-300">Tags dans les résultats</h3>
+                                <h3 className="text-lg font-semibold text-emerald-900 dark:text-emerald-300">Mots-clés dans les résultats</h3>
                             </div>
                             <div className="flex flex-wrap gap-2">
                                 {Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1]).slice(0, 15).map(([tag, count]) => (
@@ -224,12 +224,12 @@ export const Dhikrs: React.FC = () => {
                                 <Filter className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                             </div>
                             <select
-                                aria-label="Filtrer par tag"
+                                aria-label="Filtrer par mot-clé"
                                 className="w-full pl-4 pr-10 py-3 rounded-xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-gray-800 text-gray-900 dark:text-white appearance-none font-medium cursor-pointer"
                                 value={selectedTag || ''}
                                 onChange={(e) => { setSelectedTag(e.target.value || null); setSelectedCategory(null); }}
                             >
-                                <option value="">🏷️ Tous les tags</option>
+                                <option value="">🏷️ Tous les mots-clés</option>
                                 {allTags.map(tag => (
                                     <option key={tag} value={tag}>
                                         {tag}{tagCounts.get(tag) ? ` (${tagCounts.get(tag)})` : ''}

--- a/src/pages/Douaas.tsx
+++ b/src/pages/Douaas.tsx
@@ -124,7 +124,7 @@ const DouaaModal: React.FC<{ douaa: Douaa; onClose: () => void; onTagClick?: (ta
                     {tags.length > 0 && (
                         <div>
                             <p className="text-sm font-semibold text-amber-700 dark:text-amber-300 mb-2 flex items-center gap-2">
-                                <Tags className="h-4 w-4" />Tags associés :
+                                <Tags className="h-4 w-4" />Mots-clés :
                             </p>
                             <div className="flex flex-wrap gap-2">
                                 {tags.map(tag => (
@@ -169,7 +169,7 @@ const TagSelector: React.FC<{
                     className="w-full flex items-center justify-between gap-2 px-4 py-3 rounded-xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-gray-800 text-gray-900 dark:text-white hover:border-emerald-300 transition-colors">
                 <div className="flex items-center gap-2">
                     <Filter className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-                    <span className="font-medium">{selectedTag ? `Tag: ${selectedTag}` : 'Filtrer par tag'}</span>
+                    <span className="font-medium">{selectedTag ? `Mot-clé: ${selectedTag}` : 'Filtrer par mot-clé'}</span>
                 </div>
                 <ChevronDown className={`h-5 w-5 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
             </button>
@@ -180,7 +180,7 @@ const TagSelector: React.FC<{
                         <div className="p-3 border-b border-emerald-200 dark:border-emerald-800">
                             <div className="relative">
                                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                                <input type="text" placeholder="Rechercher un tag..." value={searchQuery}
+                                <input type="text" placeholder="Rechercher un mot-clé..." value={searchQuery}
                                        onChange={(e) => setSearchQuery(e.target.value)}
                                        className="w-full pl-9 pr-3 py-2 rounded-lg border border-emerald-200 dark:border-emerald-700 bg-gray-50 dark:bg-gray-900 text-sm focus:ring-2 focus:ring-emerald-500 focus:border-transparent" />
                             </div>
@@ -189,8 +189,8 @@ const TagSelector: React.FC<{
                             <button onClick={() => { onTagSelect(null); setIsOpen(false); setSearchQuery(''); }}
                                     className={`w-full text-left px-4 py-2 hover:bg-emerald-50 dark:hover:bg-emerald-900/50 transition-colors ${!selectedTag ? 'bg-emerald-100 dark:bg-emerald-900/30 font-medium' : ''}`}>
                                 <div className="flex items-center justify-between">
-                                    <span>🏷️ Tous les tags</span>
-                                    <span className="text-xs text-gray-500">{allTags.length} tags</span>
+                                    <span>🏷️ Tous les mots-clés</span>
+                                    <span className="text-xs text-gray-500">{allTags.length} mots-clés</span>
                                 </div>
                             </button>
                             {filteredTags.length > 0 ? filteredTags.map(tag => (
@@ -202,7 +202,7 @@ const TagSelector: React.FC<{
                                     {tagCounts.get(tag) ? <span className="text-xs text-gray-500">({tagCounts.get(tag)})</span> : null}
                                 </button>
                             )) : (
-                                <div className="px-4 py-8 text-center text-gray-500">Aucun tag trouvé pour "{searchQuery}"</div>
+                                <div className="px-4 py-8 text-center text-gray-500">Aucun mot-clé trouvé pour "{searchQuery}"</div>
                             )}
                         </div>
                     </motion.div>
@@ -335,7 +335,7 @@ export const Douaas: React.FC = () => {
                                 <Search className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                             </div>
                             <input type="text" aria-label="Rechercher une invocation"
-                                   placeholder="Rechercher par texte arabe, français, phonétique, tag..."
+                                   placeholder="Rechercher par texte arabe, français, phonétique, mot-clé..."
                                    className="w-full pl-12 pr-6 py-3 rounded-xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-emerald-500 focus:border-transparent text-lg font-amiri"
                                    value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
                         </div>

--- a/src/pages/Hadiths.tsx
+++ b/src/pages/Hadiths.tsx
@@ -287,7 +287,7 @@ const TagSelector: React.FC<{
           <div className="flex items-center gap-2">
             <Filter className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
             <span className="font-medium">
-            {selectedTag ? `Tag: ${selectedTag}` : 'Filtrer par tag'}
+            {selectedTag ? `Mot-clé: ${selectedTag}` : 'Filtrer par mot-clé'}
           </span>
           </div>
           <ChevronDown className={`h-5 w-5 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
@@ -306,7 +306,7 @@ const TagSelector: React.FC<{
                     <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
                     <input
                         type="text"
-                        placeholder="Rechercher un tag..."
+                        placeholder="Rechercher un mot-clé..."
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
                         className="w-full pl-9 pr-3 py-2 rounded-lg border border-emerald-200 dark:border-emerald-700 bg-gray-50 dark:bg-gray-900 text-sm focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
@@ -320,8 +320,8 @@ const TagSelector: React.FC<{
                       className={`w-full text-left px-4 py-2 hover:bg-emerald-50 dark:hover:bg-emerald-900/50 transition-colors ${!selectedTag ? 'bg-emerald-100 dark:bg-emerald-900/30 font-medium' : ''}`}
                   >
                     <div className="flex items-center justify-between">
-                      <span>🏷️ Tous les tags</span>
-                      <span className="text-xs text-gray-500">{allTags.length} tags</span>
+                      <span>🏷️ Tous les mots-clés</span>
+                      <span className="text-xs text-gray-500">{allTags.length} mots-clés</span>
                     </div>
                   </button>
 
@@ -344,7 +344,7 @@ const TagSelector: React.FC<{
                       })
                   ) : (
                       <div className="px-4 py-8 text-center text-gray-500">
-                        Aucun tag trouvé pour "{searchQuery}"
+                        Aucun mot-clé trouvé pour "{searchQuery}"
                       </div>
                   )}
                 </div>
@@ -639,7 +639,7 @@ export const Hadiths: React.FC = () => {
                         <> / <span className="font-bold">{totalCount}</span></>
                     )}
                     {' '}résultat{hadiths.length !== 1 ? 's' : ''}
-                    {selectedTag && <> pour le tag <span className="font-bold">{selectedTag}</span></>}
+                    {selectedTag && <> pour le mot-clé <span className="font-bold">{selectedTag}</span></>}
                     {searchTerm && <> pour "<span className="font-bold">{searchTerm}</span>"</>}
                   </p>
                 </div>
@@ -712,7 +712,7 @@ export const Hadiths: React.FC = () => {
                 <input
                     type="text"
                     aria-label="Rechercher un hadith"
-                    placeholder="Rechercher par texte arabe, français, phonétique, tag..."
+                    placeholder="Rechercher par texte arabe, français, phonétique, mot-clé..."
                     className="w-full pl-12 pr-6 py-3 rounded-xl border border-emerald-200 dark:border-emerald-800 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-emerald-500 focus:border-transparent text-lg font-amiri"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}


### PR DESCRIPTION
Changed filter labels from "tag" to "mot-clé" (keyword) for better UX:
- "Filtrer par tag" → "Filtrer par mot-clé"
- "Tous les tags" → "Tous les mots-clés"
- "Tags associés" → "Mots-clés"
- "Tags dans les résultats" → "Mots-clés dans les résultats"

https://claude.ai/code/session_01W2eoSCW4xu35AeyGNZCU2R