### PR TITLE
Zéro erreur TypeScript + rétablissement date hijri et horaires d'origine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/supabase-js": "^2.93.3",
         "framer-motion": "^11.0.8",
         "lucide-react": "^0.525.0",
+        "moment-hijri": "^3.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.4",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
+        "@types/moment-hijri": "^2.1.4",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@types/react-window": "^1.8.8",
@@ -3161,6 +3163,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/moment-hijri": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/moment-hijri/-/moment-hijri-2.1.4.tgz",
+      "integrity": "sha512-pGX1DaSducJDkJAC3q8fCuemow0pzI4oa0iKcspwQNPXuwlI55WRgBVrA6NVi+rf8bZN1qjWVsGdUatrLhZk6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": ">=2.14.0"
+      }
     },
     "node_modules/@types/node": {
       "version": "26.1.0",
@@ -6844,6 +6856,24 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-hijri": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/moment-hijri/-/moment-hijri-3.0.0.tgz",
+      "integrity": "sha512-UcBcbHDA8ToVcKjY+vBEa/hI3GZYraueavWUSLY2TdrHDHhx+wUpRw96rssAqsbT4xo/TMimwQVBP4KhJ3EN5A==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.30.1"
       }
     },
     "node_modules/motion-dom": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:android": "vite build && npx cap sync android",
     "android": "npm run build:android && npx cap open android",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@supabase/supabase-js": "^2.93.3",
     "framer-motion": "^11.0.8",
     "lucide-react": "^0.525.0",
+    "moment-hijri": "^3.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.4",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@types/moment-hijri": "^2.1.4",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@types/react-window": "^1.8.8",

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,20 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { m, AnimatePresence } from 'framer-motion';
 import { Book, Heart, Wind, GraduationCap, Video, Clock, BookOpen, Moon, Sun, Menu, X, Bookmark, ScrollText } from 'lucide-react';
 import { useTheme } from '../context/ThemeContext';
-
-// Date hijri via l'API Intl native (calendrier islamique Umm al-Qura) :
-// évite d'embarquer moment + moment-hijri (~70 KB gzip) pour une seule date.
-const formatHijriDate = (): string => {
-    try {
-        return new Intl.DateTimeFormat('fr-u-ca-islamic-umalqura', {
-            day: 'numeric',
-            month: 'long',
-            year: 'numeric',
-        }).format(new Date());
-    } catch {
-        return '';
-    }
-};
+import moment from 'moment-hijri';
 
 const navItems = [
     { to: '/coran', icon: Bookmark, label: 'Coran' },
@@ -39,7 +26,7 @@ export const Navigation: React.FC = () => {
 
     useEffect(() => {
         const updateHijriDate = () => {
-            setHijriDate(formatHijriDate());
+            setHijriDate(moment().format('iD iMMMM iYYYY'));
         };
         updateHijriDate();
         const interval = setInterval(updateHijriDate, 86400000);

--- a/src/context/CroyanceProvider.tsx
+++ b/src/context/CroyanceProvider.tsx
@@ -31,7 +31,7 @@ export const CroyanceProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     setIsLoading(true);
     setError(null);
     try {
-      const response = await api.get('/croyances'); // Endpoint pour récupérer les croyances
+      const response = await api.get<Croyance[]>('/croyances'); // Endpoint pour récupérer les croyances
       setCroyances(response.data);
     } catch (error) {
       console.error('Error fetching croyances:', error);

--- a/src/context/DouaaProvider.tsx
+++ b/src/context/DouaaProvider.tsx
@@ -31,7 +31,7 @@ export const DouaaProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setIsLoading(true);
     setError(null); // Réinitialiser l'erreur avant chaque requête
     try {
-      const response = await api.get('/douaas');
+      const response = await api.get<Douaa[]>('/douaas');
       setDouaas(response.data);
     } catch (error) {
       console.error('Error fetching douaas:', error);

--- a/src/context/HadithProvider.tsx
+++ b/src/context/HadithProvider.tsx
@@ -32,7 +32,7 @@ export const HadithProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setIsLoading(true);
     setError(null); // Réinitialiser l'erreur avant chaque requête
     try {
-      const response = await api.get('/hadiths');
+      const response = await api.get<Hadith[]>('/hadiths');
       setHadiths(response.data);
     } catch (error) {
       console.error('Error fetching hadiths:', error);

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -46,7 +46,11 @@ export function useHadiths(pageSize = 50): UseDataResult<Hadith> {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const tags = dataService.getHadithTags();
+  const [tags, setTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    dataService.getHadithTags().then(setTags).catch(() => setTags([]));
+  }, []);
 
   const fetchData = useCallback(async (reset = false) => {
     setIsLoading(true);
@@ -112,7 +116,11 @@ export function useCoran(pageSize = 50): UseDataResult<Coran> {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const tags = dataService.getCoranTags();
+  const [tags, setTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    dataService.getCoranTags().then(setTags).catch(() => setTags([]));
+  }, []);
 
   const fetchData = useCallback(async (reset = false) => {
     setIsLoading(true);
@@ -178,7 +186,11 @@ export function useDhikrs(pageSize = 50): UseDataResult<Dhikr> {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const tags = dataService.getDhikrTags();
+  const [tags, setTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    dataService.getDhikrTags().then(setTags).catch(() => setTags([]));
+  }, []);
 
   const fetchData = useCallback(async (reset = false) => {
     setIsLoading(true);
@@ -244,7 +256,11 @@ export function useDouaas(pageSize = 50): UseDataResult<Douaa> {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const tags = dataService.getDouaaTags();
+  const [tags, setTags] = useState<string[]>([]);
+
+  useEffect(() => {
+    dataService.getDouaaTags().then(setTags).catch(() => setTags([]));
+  }, []);
 
   const fetchData = useCallback(async (reset = false) => {
     setIsLoading(true);
@@ -314,8 +330,13 @@ export function useSavants(pageSize = 50): UseSavantsResult {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const tags = dataService.getSavantTags();
-  const savantNames = dataService.getSavantNames();
+  const [tags, setTags] = useState<string[]>([]);
+  const [savantNames, setSavantNames] = useState<string[]>([]);
+
+  useEffect(() => {
+    dataService.getSavantTags().then(setTags).catch(() => setTags([]));
+    dataService.getSavantNames().then(setSavantNames).catch(() => setSavantNames([]));
+  }, []);
 
   const fetchData = useCallback(async (reset = false) => {
     setIsLoading(true);

--- a/src/pages/Biographies.tsx
+++ b/src/pages/Biographies.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
-import { Users, Search, Filter, X, Star, ChevronRight, BookOpen } from 'lucide-react';
+import { Users, Search, Filter, X, ChevronRight } from 'lucide-react';
 import { usePageTitle } from '../hooks/usePageTitle';
 
 export const Biographies: React.FC = () => {
@@ -81,7 +81,6 @@ export const Biographies: React.FC = () => {
   ];
 
   const categories = [...new Set(biographies.map(bio => bio.category))];
-  const allTags = [...new Set(biographies.flatMap(bio => bio.tags.split(',')))];
 
   const filteredBios = biographies.filter(bio => {
     const matchesSearch = bio.name.toLowerCase().includes(searchTerm.toLowerCase()) || 

--- a/src/pages/Coran.tsx
+++ b/src/pages/Coran.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
 import {
-  BookOpen, Search, Filter, X, Star, ChevronRight, Loader,
+  Search, Filter, X, Star, Loader,
   Tags, Hash, ChevronDown, Eye, List as ListIcon, Grid3x3
 } from 'lucide-react';
 import { dataService } from '../services/DataService';

--- a/src/pages/Dhikrs.tsx
+++ b/src/pages/Dhikrs.tsx
@@ -12,9 +12,13 @@ const getTagsArray = (tags: string | null | undefined): string[] => {
 
 const ITEMS_PER_PAGE = 20;
 
+// La colonne `categorie` n'existe pas (encore) dans la table dhikr : optionnelle
+// pour que le badge et le filtre ne s'affichent que si elle est ajoutée un jour.
+type DhikrItem = Dhikr & { categorie?: string | null };
+
 export const Dhikrs: React.FC = () => {
   usePageTitle('Dhikrs');
-    const [dhikrs, setDhikrs] = useState<Dhikr[]>([]);
+    const [dhikrs, setDhikrs] = useState<DhikrItem[]>([]);
     const [hasSearched, setHasSearched] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -41,7 +45,7 @@ export const Dhikrs: React.FC = () => {
         const counts = new Map<string, number>();
         dhikrs.forEach(d => {
             if (d.categorie) cats.add(d.categorie);
-            getTagsArray(d.tags).forEach(t => counts.set(t, (counts.get(t) || 0) + 1));
+            getTagsArray(d.tag).forEach(t => counts.set(t, (counts.get(t) || 0) + 1));
         });
         setCategories(Array.from(cats).sort());
         setTagCounts(counts);
@@ -59,7 +63,7 @@ export const Dhikrs: React.FC = () => {
         try {
             const res = await dataService.searchDhikrs(q, tag, { page: 0, pageSize: ITEMS_PER_PAGE });
             setDhikrs(res.data ?? []);
-            setTotalCount(res.total ?? 0);
+            setTotalCount(res.count ?? 0);
             setHasSearched(true);
         } catch {
             setError('Erreur lors de la recherche. Veuillez réessayer.');
@@ -352,7 +356,7 @@ export const Dhikrs: React.FC = () => {
 
                                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                                     {displayedDhikrs.map((dhikr, index) => {
-                                        const tags = getTagsArray(dhikr.tags);
+                                        const tags = getTagsArray(dhikr.tag);
                                         return (
                                             <m.div
                                                 key={dhikr.id}

--- a/src/pages/Douaas.tsx
+++ b/src/pages/Douaas.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
-import { Search, Filter, X, Star, ChevronRight, Loader, Tags, Hash, ChevronDown, Heart } from 'lucide-react';
+import { Search, Filter, X, Star, Loader, Tags, Hash, ChevronDown, Heart } from 'lucide-react';
 import { dataService } from '../services/DataService';
 import type { Douaa as DouaaType } from '../types';
 import { usePageTitle } from '../hooks/usePageTitle';
@@ -10,10 +10,9 @@ interface Douaa extends DouaaType {
     sujet: string;
     texte_arabe: string;
     texte_francais: string | null;
-    phonetique: string | null;
+    phonétique: string | null;
     explication: string | null;
     commentaire: string | null;
-    type_id: number;
     tag: string | null;
 }
 
@@ -97,10 +96,10 @@ const DouaaModal: React.FC<{ douaa: Douaa; onClose: () => void; onTagClick?: (ta
                     <h2 className="text-2xl font-bold text-amber-800 dark:text-amber-200 font-amiri">{douaa.sujet}</h2>
                     <div className="bg-amber-50 dark:bg-gray-700 p-6 rounded-lg">
                         <p className="text-3xl text-gray-900 dark:text-white font-arabic leading-loose text-right">{douaa.texte_arabe}</p>
-                        {douaa.phonetique && (
+                        {douaa.phonétique && (
                             <div className="mt-6 bg-white dark:bg-gray-600 p-4 rounded">
                                 <p className="text-sm text-amber-700 dark:text-amber-300 mb-2">Phonétique:</p>
-                                <p className="text-gray-700 dark:text-gray-200">{douaa.phonetique}</p>
+                                <p className="text-gray-700 dark:text-gray-200">{douaa.phonétique}</p>
                             </div>
                         )}
                         {douaa.texte_francais && (
@@ -256,7 +255,7 @@ export const Douaas: React.FC = () => {
         try {
             const res = await dataService.searchDouaas(q, tag, { page: 0, pageSize: ITEMS_PER_PAGE });
             setDouaas(res.data ?? []);
-            setTotalCount(res.total ?? 0);
+            setTotalCount(res.count ?? 0);
             setHasSearched(true);
         } catch {
             setError('Erreur lors de la recherche. Veuillez réessayer.');

--- a/src/pages/Hadiths.tsx
+++ b/src/pages/Hadiths.tsx
@@ -512,7 +512,7 @@ export const Hadiths: React.FC = () => {
     try {
       const res = await dataService.searchHadiths(q, tag, { page, pageSize: ITEMS_PER_PAGE });
       const items = res.data ?? [];
-      const total = res.total ?? 0;
+      const total = res.count ?? 0;
       setHadiths(prev => append ? [...prev, ...items] : items);
       setTotalCount(total);
       setHasMore((page + 1) * ITEMS_PER_PAGE < total);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,9 +5,18 @@ import { BookOpen, ChevronRight, Sun, Moon, Sunrise, Sunset, Book, Heart, Wind, 
 import { PrayerTimes } from '../components/PrayerTimes';
 import { DailyQuote } from '../components/DailyQuote';
 import { dataService } from '../services/DataService';
-import { usePrayerTimes } from '../hooks/usePrayerTimes';
+// import { usePrayerTimes } from '../hooks/usePrayerTimes'; // API horaires désactivée en attendant une API plus fiable
 import { usePageTitle } from '../hooks/usePageTitle';
 import type { Hadith, Douaa, Coran } from '../types';
+
+const mockPrayerTimes = {
+  fajr: "05:30",
+  sunrise: "06:45",
+  dhuhr: "12:30",
+  asr: "15:45",
+  maghrib: "18:15",
+  isha: "19:30"
+};
 
 const mockQuote = {
   text: "Celui pour qui Allah veut le bien, lui facilite l'apprentissage de la religion",
@@ -61,7 +70,10 @@ export const Home: React.FC = () => {
   usePageTitle();
   const [selectedCity] = useState("Paris");
   const [timeOfDay] = useState<'morning' | 'afternoon' | 'evening' | 'night'>(getTimeOfDay());
-  const { times: prayerTimes } = usePrayerTimes(selectedCity);
+  // Horaires via API désactivés pour l'instant — réactiver en remplaçant
+  // l'implémentation de src/hooks/usePrayerTimes.ts par l'API choisie :
+  // const { times: prayerTimes } = usePrayerTimes(selectedCity);
+  const prayerTimes = mockPrayerTimes;
 
   const [stats, setStats] = useState<SiteStats>({
     hadiths: 0,
@@ -433,7 +445,7 @@ export const Home: React.FC = () => {
       <footer className="bg-emerald-900 dark:bg-emerald-950 text-white py-12">
         <div className="container mx-auto px-4 text-center">
           <p className="text-emerald-300 mb-4 font-amiri text-xl">
-            « Que l'un de vous apprenne un chapitre de la religion ou l'enseigne aura plus de récompenses que de prier mille rak`ah des prières surérogatoires »
+            "Que l'un de vous apprenne un chapitre de la religion ou l'enseigne aura plus de récompenses que de prier mille rak`ah des prières surérogatoires"
           </p>
           <p className="text-emerald-200">© {new Date().getFullYear()} IslamHub - Tous droits réservés</p>
         </div>

--- a/src/pages/Jurisprudence.tsx
+++ b/src/pages/Jurisprudence.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
-import { 
-  BookOpen, Search, Filter, X, Star, ChevronRight, 
-  Heart, Sun, Moon, Scale, Gift, Home, ShoppingCart, 
-  Users,  Landmark, Utensils, Shirt, HandCoins 
+import {
+  BookOpen, Search, Filter, X, ChevronRight,
+  Heart, Sun, Moon, Scale, Gift, Home, ShoppingCart,
+  Landmark, Utensils, Shirt, HandCoins
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/pages/Madhaheb.tsx
+++ b/src/pages/Madhaheb.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { m, AnimatePresence } from 'framer-motion';
+import { m } from 'framer-motion';
 import { Link } from 'react-router-dom';
-import { GraduationCap, BookOpen, ChevronRight, Star, Users, Scale, Sun, Moon } from 'lucide-react';
+import { GraduationCap, BookOpen, ChevronRight, Star, Users, Scale } from 'lucide-react';
 import { usePageTitle } from '../hooks/usePageTitle';
 
 export const Madhaheb: React.FC = () => {

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -14,14 +14,8 @@ export const NotFound: React.FC = () => {
         animate={{ opacity: 1, y: 0 }}
         className="text-center max-w-lg"
       >
-        <p className="text-7xl mb-6 font-amiri bg-gradient-to-r from-emerald-600 to-amber-500 dark:from-emerald-400 dark:to-amber-400 bg-clip-text text-transparent font-bold">
+        <p className="text-7xl mb-8 font-amiri bg-gradient-to-r from-emerald-600 to-amber-500 dark:from-emerald-400 dark:to-amber-400 bg-clip-text text-transparent font-bold">
           404
-        </p>
-        <p className="text-2xl text-right font-amiri text-gray-700 dark:text-gray-300 mb-2 leading-loose" lang="ar" dir="rtl">
-          وَمَن يَتَوَكَّلْ عَلَى ٱللَّهِ فَهُوَ حَسْبُهُ
-        </p>
-        <p className="text-sm text-gray-500 dark:text-gray-400 italic mb-8">
-          « Et quiconque place sa confiance en Allah, Il lui suffit. » (Coran 65:3)
         </p>
         <h1 className="text-2xl font-bold text-emerald-900 dark:text-emerald-300 mb-3 font-amiri">
           Cette page n'existe pas

--- a/src/pages/PrayerTimes.tsx
+++ b/src/pages/PrayerTimes.tsx
@@ -1,23 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
-import { Calendar, MapPin, Search, ChevronRight, Loader2 } from 'lucide-react';
+import { Calendar, MapPin, Search, ChevronRight } from 'lucide-react';
 import { PrayerTimes as PrayerTimesComponent } from '../components/PrayerTimes';
-import { usePrayerTimes } from '../hooks/usePrayerTimes';
+// import { usePrayerTimes } from '../hooks/usePrayerTimes'; // API horaires désactivée en attendant une API plus fiable
 import { usePageTitle } from '../hooks/usePageTitle';
+
+const mockPrayerTimes = {
+  fajr: "05:30",
+  sunrise: "06:45",
+  dhuhr: "12:30",
+  asr: "15:45",
+  maghrib: "18:15",
+  isha: "19:30"
+};
 
 interface CityOption {
   name: string;
   country: string;
-}
-
-interface CalendarDay {
-  date: string;
-  fajr: string;
-  sunrise: string;
-  dhuhr: string;
-  asr: string;
-  maghrib: string;
-  isha: string;
 }
 
 const cities: CityOption[] = [
@@ -29,93 +28,109 @@ const cities: CityOption[] = [
   { name: "Dubai", country: "UAE" }
 ];
 
-const cleanTime = (value: string): string => value.split(' ')[0];
-
-/**
- * Calendrier du mois via AlAdhan (méthode 12 - UOIF), mis en cache
- * dans localStorage par ville et par mois.
- */
-function useMonthlyCalendar(city: string, country: string) {
-  const [days, setDays] = useState<CalendarDay[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    const now = new Date();
-    const month = now.getMonth() + 1;
-    const year = now.getFullYear();
-    const cacheKey = `prayer-calendar:${city}:${year}-${month}`;
-
-    const fetchCalendar = async () => {
-      setIsLoading(true);
-
-      try {
-        const cached = localStorage.getItem(cacheKey);
-        if (cached) {
-          if (!cancelled) {
-            setDays(JSON.parse(cached) as CalendarDay[]);
-            setIsLoading(false);
-          }
-          return;
-        }
-      } catch {
-        // cache illisible : on continue vers le réseau
-      }
-
-      try {
-        const response = await fetch(
-          `https://api.aladhan.com/v1/calendarByCity/${year}/${month}?city=${encodeURIComponent(city)}&country=${encodeURIComponent(country)}&method=12`
-        );
-        if (!response.ok) throw new Error(`AlAdhan API: ${response.status}`);
-
-        const json = await response.json();
-        const result: CalendarDay[] = (json?.data || []).map((day: {
-          date: { readable: string };
-          timings: Record<string, string>;
-        }) => ({
-          date: day.date.readable,
-          fajr: cleanTime(day.timings.Fajr),
-          sunrise: cleanTime(day.timings.Sunrise),
-          dhuhr: cleanTime(day.timings.Dhuhr),
-          asr: cleanTime(day.timings.Asr),
-          maghrib: cleanTime(day.timings.Maghrib),
-          isha: cleanTime(day.timings.Isha),
-        }));
-
-        try {
-          localStorage.setItem(cacheKey, JSON.stringify(result));
-        } catch {
-          // stockage plein : tant pis pour le cache
-        }
-
-        if (!cancelled) setDays(result);
-      } catch (err) {
-        console.error('Error fetching prayer calendar:', err);
-        if (!cancelled) setDays([]);
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    };
-
-    fetchCalendar();
-    return () => {
-      cancelled = true;
-    };
-  }, [city, country]);
-
-  return { days, isLoading };
-}
+// Calendrier mensuel via API — désactivé en attendant une API plus fiable.
+// Réactiver en décommentant ce bloc et les appels dans le composant.
+// interface CalendarDay {
+//   date: string;
+//   fajr: string;
+//   sunrise: string;
+//   dhuhr: string;
+//   asr: string;
+//   maghrib: string;
+//   isha: string;
+// }
+//
+// const cleanTime = (value: string): string => value.split(' ')[0];
+//
+// /**
+//  * Calendrier du mois via AlAdhan (méthode 12 - UOIF), mis en cache
+//  * dans localStorage par ville et par mois.
+//  */
+// function useMonthlyCalendar(city: string, country: string) {
+//   const [days, setDays] = useState<CalendarDay[]>([]);
+//   const [isLoading, setIsLoading] = useState(true);
+//
+//   useEffect(() => {
+//     let cancelled = false;
+//     const now = new Date();
+//     const month = now.getMonth() + 1;
+//     const year = now.getFullYear();
+//     const cacheKey = `prayer-calendar:${city}:${year}-${month}`;
+//
+//     const fetchCalendar = async () => {
+//       setIsLoading(true);
+//
+//       try {
+//         const cached = localStorage.getItem(cacheKey);
+//         if (cached) {
+//           if (!cancelled) {
+//             setDays(JSON.parse(cached) as CalendarDay[]);
+//             setIsLoading(false);
+//           }
+//           return;
+//         }
+//       } catch {
+//         // cache illisible : on continue vers le réseau
+//       }
+//
+//       try {
+//         const response = await fetch(
+//           `https://api.aladhan.com/v1/calendarByCity/${year}/${month}?city=${encodeURIComponent(city)}&country=${encodeURIComponent(country)}&method=12`
+//         );
+//         if (!response.ok) throw new Error(`AlAdhan API: ${response.status}`);
+//
+//         const json = await response.json();
+//         const result: CalendarDay[] = (json?.data || []).map((day: {
+//           date: { readable: string };
+//           timings: Record<string, string>;
+//         }) => ({
+//           date: day.date.readable,
+//           fajr: cleanTime(day.timings.Fajr),
+//           sunrise: cleanTime(day.timings.Sunrise),
+//           dhuhr: cleanTime(day.timings.Dhuhr),
+//           asr: cleanTime(day.timings.Asr),
+//           maghrib: cleanTime(day.timings.Maghrib),
+//           isha: cleanTime(day.timings.Isha),
+//         }));
+//
+//         try {
+//           localStorage.setItem(cacheKey, JSON.stringify(result));
+//         } catch {
+//           // stockage plein : tant pis pour le cache
+//         }
+//
+//         if (!cancelled) setDays(result);
+//       } catch (err) {
+//         console.error('Error fetching prayer calendar:', err);
+//         if (!cancelled) setDays([]);
+//       } finally {
+//         if (!cancelled) setIsLoading(false);
+//       }
+//     };
+//
+//     fetchCalendar();
+//     return () => {
+//       cancelled = true;
+//     };
+//   }, [city, country]);
+//
+//   return { days, isLoading };
+// }
+//
 
 export const PrayerTimesPage: React.FC = () => {
   usePageTitle('Horaires de prière');
   const [selectedCity, setSelectedCity] = useState<CityOption>(cities[0]);
   const [searchTerm, setSearchTerm] = useState("");
 
-  const { times } = usePrayerTimes(selectedCity.name, selectedCity.country);
-  const { days: calendarDays, isLoading: isCalendarLoading } = useMonthlyCalendar(
-    selectedCity.name,
-    selectedCity.country
-  );
+  // Horaires via API désactivés pour l'instant — réactiver en remplaçant
+  // l'implémentation des hooks (usePrayerTimes / useMonthlyCalendar) par l'API choisie :
+  // const { times } = usePrayerTimes(selectedCity.name, selectedCity.country);
+  // const { days: calendarDays, isLoading: isCalendarLoading } = useMonthlyCalendar(
+  //   selectedCity.name,
+  //   selectedCity.country
+  // );
+  const times = mockPrayerTimes;
 
   const filteredCities = cities.filter(city =>
     city.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -272,52 +287,42 @@ export const PrayerTimesPage: React.FC = () => {
                 Calendrier Mensuel
               </h2>
               <p className="text-sm text-emerald-700 dark:text-emerald-400">
-                Consultez les horaires pour tout le mois — {selectedCity.name}
+                Consultez les horaires pour tout le mois
               </p>
             </div>
           </div>
 
-          {isCalendarLoading ? (
-            <div className="flex justify-center items-center py-16">
-              <Loader2 className="w-8 h-8 text-emerald-600 dark:text-emerald-400 animate-spin" />
-            </div>
-          ) : calendarDays.length === 0 ? (
-            <p className="text-center py-8 text-gray-500 dark:text-gray-400">
-              Calendrier indisponible pour le moment
-            </p>
-          ) : (
-            <div className="overflow-x-auto max-h-[28rem] overflow-y-auto">
-              <table className="w-full">
-                <thead className="sticky top-0 bg-amber-50 dark:bg-emerald-900">
-                  <tr>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Date</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Fajr</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Chourouq</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Dhuhr</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Asr</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Maghrib</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Isha</th>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Date</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Fajr</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Sunrise</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Dhuhr</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Asr</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Maghrib</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-emerald-800 dark:text-emerald-300">Isha</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[1, 2, 3].map((day) => (
+                  <tr
+                    key={day}
+                    className="border-t border-amber-200 dark:border-emerald-800 hover:bg-amber-50 dark:hover:bg-emerald-900/30"
+                  >
+                    <td className="px-4 py-3 text-gray-800 dark:text-gray-200">Mars {day}</td>
+                    <td className="px-4 py-3 text-gray-800 dark:text-gray-200">05:30</td>
+                    <td className="px-4 py-3 text-gray-800 dark:text-gray-200">06:45</td>
+                    <td className="px-4 py-3 text-gray-800 dark:text-gray-200">12:30</td>
+                    <td className="px-4 py-3 text-gray-800 dark:text-gray-200">15:45</td>
+                    <td className="px-4 py-3 text-gray-800 dark:text-gray-200">18:15</td>
+                    <td className="px-4 py-3 text-gray-800 dark:text-gray-200">19:30</td>
                   </tr>
-                </thead>
-                <tbody>
-                  {calendarDays.map((day) => (
-                    <tr
-                      key={day.date}
-                      className="border-t border-amber-200 dark:border-emerald-800 hover:bg-amber-50 dark:hover:bg-emerald-900/30"
-                    >
-                      <td className="px-4 py-3 text-gray-800 dark:text-gray-200 whitespace-nowrap">{day.date}</td>
-                      <td className="px-4 py-3 text-gray-800 dark:text-gray-200">{day.fajr}</td>
-                      <td className="px-4 py-3 text-gray-800 dark:text-gray-200">{day.sunrise}</td>
-                      <td className="px-4 py-3 text-gray-800 dark:text-gray-200">{day.dhuhr}</td>
-                      <td className="px-4 py-3 text-gray-800 dark:text-gray-200">{day.asr}</td>
-                      <td className="px-4 py-3 text-gray-800 dark:text-gray-200">{day.maghrib}</td>
-                      <td className="px-4 py-3 text-gray-800 dark:text-gray-200">{day.isha}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+                ))}
+              </tbody>
+            </table>
+          </div>
         </m.div>
       </main>
 

--- a/src/pages/Repliques.tsx
+++ b/src/pages/Repliques.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
-import { BookOpen, Search, Filter, X, Star, ChevronRight } from 'lucide-react';
+import { BookOpen, Search, Filter, X, ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 const Repliques: React.FC = () => {
@@ -75,7 +75,6 @@ const Repliques: React.FC = () => {
   ];
 
   const categories = [...new Set(repliques.map(item => item.category))];
-  const allTags = [...new Set(repliques.flatMap(item => item.tags.split(',')))];
 
   const handleTopicClick = (title: string) => {
     const replique = repliques.find(r => r.title === title);

--- a/src/pages/Savants.tsx
+++ b/src/pages/Savants.tsx
@@ -11,7 +11,7 @@ interface Savant {
   savant: string;
   texte_arabe: string;
   texte_francais: string | null;
-  phonetique: string | null;
+  phonétique: string | null;
   explication: string | null;
   tag: string;
 }
@@ -129,10 +129,10 @@ const SavantModal: React.FC<{
               {savant.texte_arabe}
             </p>
             
-            {savant.phonetique && (
+            {savant.phonétique && (
               <div className="mt-6 bg-white dark:bg-gray-600 p-4 rounded">
                 <p className="text-sm text-amber-700 dark:text-amber-300 mb-2">Phonétique:</p>
-                <p className="text-gray-700 dark:text-gray-200">{savant.phonetique}</p>
+                <p className="text-gray-700 dark:text-gray-200">{savant.phonétique}</p>
               </div>
             )}
             
@@ -275,7 +275,7 @@ useEffect(() => {
         (savant.texte_francais?.toLowerCase().includes(term)) ||
         (savant.explication?.toLowerCase().includes(term)) ||
         savant.sujet.toLowerCase().includes(term) ||
-        (savant.rapporteur?.toLowerCase().includes(term))
+        savant.savant.toLowerCase().includes(term)
       );
     }
 

--- a/src/pages/ecoles/Hanafi.tsx
+++ b/src/pages/ecoles/Hanafi.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
 import { Link } from 'react-router-dom';
-import { Scale, BookOpen, Users, Star, ChevronRight, GraduationCap, Lightbulb, Globe, ChevronDown, ChevronUp, Heart, Shield, Sparkles, Calendar, BookMarked } from 'lucide-react';
+import { Scale, BookOpen, Users, Star, ChevronRight, Lightbulb, Globe, ChevronDown, ChevronUp, Heart, Shield, Sparkles, Calendar, BookMarked } from 'lucide-react';
 
 interface SectionProps {
     title: string;

--- a/src/pages/ecoles/Malikite.tsx
+++ b/src/pages/ecoles/Malikite.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
 import { Link } from 'react-router-dom';
-import { BookOpen, Users, Star, ChevronRight, Scale, GraduationCap, Globe, Building, Heart, ChevronDown, ChevronUp, Shield, Sparkles, Calendar, BookMarked } from 'lucide-react';
+import { BookOpen, Users, Star, ChevronRight, Scale, Globe, Building, Heart, ChevronDown, ChevronUp, Shield, Sparkles, Calendar, BookMarked } from 'lucide-react';
 
 interface SectionProps {
     title: string;

--- a/src/pages/ecoles/Shafii.tsx
+++ b/src/pages/ecoles/Shafii.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { m, AnimatePresence } from 'framer-motion';
 import { Link } from 'react-router-dom';
-import { GraduationCap, BookOpen, Users, Star, ChevronRight, Scale, Globe, Shield, Heart, ChevronDown, ChevronUp, Calendar, Scroll, MapPin, Sparkles } from 'lucide-react';
+import { GraduationCap, BookOpen, Users, Star, ChevronRight, Scale, Globe, Shield, Heart, ChevronDown, ChevronUp, Calendar, Scroll } from 'lucide-react';
 
 interface SectionProps {
     title: string;

--- a/src/pages/hadith/Al-Bukhari/index.tsx
+++ b/src/pages/hadith/Al-Bukhari/index.tsx
@@ -1,2 +1,0 @@
-export { default as AlBukhari } from './AlBukhari';
-export { default as partA } from './AlBukhari/part1';

--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -60,7 +60,7 @@ let currentDataSource = detectDataSource();
 // Fonctions utilitaires
 // ==========================================
 
-function extractTags<T extends { tag?: string }>(items: T[]): string[] {
+function extractTags<T extends { tag?: string | null }>(items: T[]): string[] {
   const tagsSet = new Set<string>();
   items.forEach(item => {
     if (item.tag) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export interface BaseText {
   texte_francais: string | null;
   phonétique: string | null;
   explication: string | null;
-  tag: string;
+  tag: string | null;
 }
 
 /** Hadith - Parole du Prophète (ﷺ) */


### PR DESCRIPTION
## Résumé

Deux volets : correction des 58 erreurs TypeScript (`tsc --noEmit` passe à zéro), puis rétablissement de la date hijri et des horaires de prière d'origine suite aux retours (API conservée en commentaire).

## Corrections TypeScript (58 → 0)

Plusieurs erreurs de types cachaient de **vrais bugs d'affichage**, corrigés au passage :
- **Dhikrs** : le nuage de mots-clés ne s'affichait jamais (`d.tags` au lieu de `d.tag`) et le compteur de résultats restait à 0 (`res.total` au lieu de `res.count`) — même bug de compteur corrigé sur Douaas et Hadiths
- **Savants/Douaas** : la translittération ne s'affichait jamais (`phonetique` sans accent alors que les données utilisent `phonétique`)
- **Savants** : la recherche filtrait sur un champ `rapporteur` inexistant → recherche sur le nom du savant
- **useData.ts** : les tags étaient des Promises jamais résolues assignées au state → chargement via `useEffect`
- Providers express : réponses fetch typées (`api.get<T>`)

Alignement des types :
- `BaseText.tag` passe en `string | null` (reflète la BDD), `extractTags` ajusté
- Douaas : `type_id` retiré (colonne inexistante) ; Dhikrs : `categorie` en extension locale optionnelle (colonne absente du schéma actuel)

Nettoyage :
- Imports lucide et variables inutilisés supprimés (10 fichiers)
- Suppression de `hadith/Al-Bukhari/index.tsx` (mort, importait `part1` disparu)
- Script npm `typecheck` ajouté pour éviter les régressions

## Rétablissements (retours utilisateur)

- **Date hijri** : retour à `moment-hijri` (l'API `Intl` donnait une date incorrecte) ; `@types/moment-hijri` ajouté
- **Horaires de prière** : retour aux valeurs d'origine sur l'accueil et la page Horaires, calendrier mensuel d'origine rétabli ; les appels à l'API AlAdhan (`usePrayerTimes` / `useMonthlyCalendar`) restent **en commentaire** pour brancher une API plus fiable plus tard
- **Page 404** : retrait du verset ajouté par erreur ; guillemets d'origine restaurés sur la citation du footer de l'accueil — aucun texte religieux ajouté ni modifié

## Vérification

- `npm run typecheck` : 0 erreur ; ESLint : 0 erreur ; `vite build` OK
- Testé sur le build de prod dans Chromium (Playwright) : accueil (date hijri `17 محرم 1448`, horaires d'origine), Dhikrs (recherche + tags + compteur), Savants, Douaas, Horaires, 404 — aucune erreur JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LyoBDUqT81dSZtuTiqNgs

---
_Generated by [Claude Code](https://claude.ai/code/session_016LyoBDUqT81dSZtuTiqNgs)_