### PR TITLE
Protège la date hijri contre la traduction automatique du navigateur

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -103,7 +103,9 @@ export const Navigation: React.FC = () => {
                             transition={{ delay: 0.3 }}
                             className="hidden lg:flex items-center px-3 py-1 rounded-full bg-emerald-100/50 dark:bg-emerald-900/30 border border-emerald-200/50 dark:border-emerald-700/50"
                         >
-                            <span className="text-sm text-emerald-700 dark:text-emerald-300 font-amiri whitespace-nowrap">
+                            {/* translate="no" : empêche la traduction automatique du navigateur
+                                de déformer la date hijri (محرم → « janvier », ère « av. J.-C. »…) */}
+                            <span className="text-sm text-emerald-700 dark:text-emerald-300 font-amiri whitespace-nowrap" translate="no" lang="ar" dir="rtl">
                                 {hijriDate}
                             </span>
                         </m.div>
@@ -246,7 +248,7 @@ export const Navigation: React.FC = () => {
                             <div className="py-4 space-y-1">
                                 {/* Hijri Date - Mobile */}
                                 <div className="flex justify-center mb-4">
-                                    <span className="px-4 py-2 rounded-full bg-emerald-100/50 dark:bg-emerald-900/30 border border-emerald-200/50 dark:border-emerald-700/50 text-sm text-emerald-700 dark:text-emerald-300 font-amiri">
+                                    <span className="px-4 py-2 rounded-full bg-emerald-100/50 dark:bg-emerald-900/30 border border-emerald-200/50 dark:border-emerald-700/50 text-sm text-emerald-700 dark:text-emerald-300 font-amiri" translate="no" lang="ar" dir="rtl">
                                         {hijriDate}
                                     </span>
                                 </div>


### PR DESCRIPTION
## Résumé

La date hijri affichée par le site est correcte (« ١٧ محرم 1448 » via moment-hijri, vérifié dans le bundle de production), mais la fonction « Traduire cette page » de Chrome/Edge la déformait chez l'utilisateur : le mois arabe محرم devenait « janvier » et une ère « av. J.-C. » était ajoutée.

## Changements

- `translate="no"` sur les deux badges de date hijri (desktop et mobile) dans `Navigation.tsx` — les navigateurs n'y appliqueront plus la traduction automatique, quel que soit le réglage du visiteur
- `lang="ar" dir="rtl"` sur ces mêmes badges pour un rendu correct du texte arabe

Aucun texte n'est modifié — uniquement des attributs HTML.

## Vérification

- `npm run typecheck` : 0 erreur ; ESLint OK ; `vite build` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LyoBDUqT81dSZtuTiqNgs

---
_Generated by [Claude Code](https://claude.ai/code/session_016LyoBDUqT81dSZtuTiqNgs)_